### PR TITLE
Different ace source

### DIFF
--- a/interruption/goes_data_set.py
+++ b/interruption/goes_data_set.py
@@ -157,7 +157,7 @@ def fetch_GOES_data(time_start, time_stop, pathing_dict):
     # --- Once the data indices have been found, load that selection into an astropy table
     #
     goes_table = ascii.read(
-        data_file, data_start=data_start - 3, data_end=data_stop - 2
+        data_file, data_start=data_start - 3, data_end=data_stop - 2, header_start = 0
     )
     return goes_table
 

--- a/interruption/run_interruption.py
+++ b/interruption/run_interruption.py
@@ -37,6 +37,7 @@ WEB_DIR = "/data/mta_www/mta_interrupt"
 OUT_WEB_DIR = "/data/mta_www/mta_interrupt"
 SPACE_WEATHER_DIR = "/data/mta4/Space_Weather"
 INTERRUPT_DIR = "/data/mta/Script/Interrupt"
+ACE_DIR = "/data/mta4/Space_Weather/ACE"
 
 _PATHING_DICT = {
     "BIN_DIR": BIN_DIR,
@@ -46,6 +47,7 @@ _PATHING_DICT = {
     "OUT_WEB_DIR": OUT_WEB_DIR,
     "SPACE_WEATHER_DIR": SPACE_WEATHER_DIR,
     "INTERRUPT_DIR": INTERRUPT_DIR,
+    "ACE_DIR": ACE_DIR
 }  #: Dictionary of input and output file paths for collecting all interruption data.
 
 TIME_FORMATS = [
@@ -273,6 +275,7 @@ if __name__ == "__main__":
             "OUT_WEB_DIR": f"{BIN_DIR}/test/_outTest",
             "SPACE_WEATHER_DIR": SPACE_WEATHER_DIR,
             "INTERRUPT_DIR": INTERRUPT_DIR,
+            "ACE_DIR": ACE_DIR
         }
         run_interrupt(event_data, pathing_dict)
 


### PR DESCRIPTION
This PR adjusts the science run interruption generation script to use the ace.archive data source rather than a separate file copy of equivalent archive data.